### PR TITLE
대기정보에 대한 로직 구체화와 스켈레톤 코드 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 !**/src/test/**
 /logs/
 /testResults/
+/bin/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/com/example/dust/controller/ForecastController.java
+++ b/src/main/java/com/example/dust/controller/ForecastController.java
@@ -2,6 +2,7 @@ package com.example.dust.controller;
 
 import com.example.dust.bean.*;
 import com.example.dust.message.SuccessMessages;
+import com.example.dust.metadata.ApiKey;
 import com.example.dust.metadata.ApiParams;
 import com.example.dust.metadata.ApiUrl;
 import com.example.dust.util.ConnectionUtil;
@@ -16,15 +17,57 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RestController
 @RequestMapping("/forecast")
 public class ForecastController {
 
-  public String getStation() {
-    log.debug("### getStation");
+  public Map<String, String> transferCoord(String x, String y) throws Exception {
+    log.info("### getCoord");
+
+    URL url = new URL(ApiUrl.TRANSFER_COORDINATE + "?"
+                      + ApiParams.X + x + "&"
+                      + ApiParams.Y + y + "&"
+                      + ApiParams.INPUT_COORD + "&"
+                      + ApiParams.OUTPUT_COORD
+    );
+
+    log.info("### URL: {}", url);
+
+    String responseFromOpenApi = ConnectionUtil.getResponseFromOpenAPi(url, ApiKey.TRANSFER_COORDINATE_KEY);
+    log.info("### responseFromOpenApi: {}", responseFromOpenApi);
+
+    Map<String, String> tmMap = new HashMap<>();
+    tmMap.put("tmX", "244148.546388");
+    tmMap.put("tmY", "412423.75772");
+
+    return tmMap;
+  }
+
+  public String getStation() throws Exception {
+    log.info("### getStation");
+
+    String x = "127.0266961";
+    String y = "37.575747";
+
+    Map<String, String> tmMap = transferCoord(x, y);
+
+    URL url = new URL(ApiUrl.STATION + "?"
+                      + ApiParams.STATION_SERVICE_KEY + "&"
+                      + ApiParams.TM_X + tmMap.get("tmX") + "&"
+                      + ApiParams.TM_Y + tmMap.get("tmY") + "&"
+                      + ApiParams.VER + "&"
+                      + ApiParams.RETURN_TYPE_JSON
+    );
+
+    log.info("### URL: {}", url);
+
+    String responseFromOpenApi = ConnectionUtil.getResponseFromOpenAPi(url, ApiKey.TRANSFER_COORDINATE_KEY);
+    log.info("### responseFromOpenApi: {}", responseFromOpenApi);
 
     return "종로구";
   }
@@ -34,11 +77,11 @@ public class ForecastController {
     log.info("### info dustStatus");
 
     URL url = new URL(ApiUrl.DUST_STATUS + "?"
-        + ApiParams.FORECAST_SERVICE_KEY + "&"
-        + ApiParams.STATION_NAME + "&"
-        + ApiParams.DATA_TERM + "&"
-        + ApiParams.VERSION + "&"
-        + ApiParams.RETURN_TYPE
+                      + ApiParams.FORECAST_SERVICE_KEY + "&"
+                      + ApiParams.STATION_NAME + getStation() + "&"
+                      + ApiParams.DATA_TERM + "&"
+                      + ApiParams.VERSION + "&"
+                      + ApiParams.RETURN_TYPE_JSON
     );
     log.info("### URL: {}", url);
 
@@ -57,7 +100,7 @@ public class ForecastController {
                       + ApiParams.FORECAST_SERVICE_KEY + "&"
                       + ApiParams.SEARCH_DATE + "&"
                       + ApiParams.INFORM_CODE + "&"
-                      + ApiParams.RETURN_TYPE
+                      + ApiParams.RETURN_TYPE_JSON
     );
 
     String responseFormOpenApi = ConnectionUtil.getResponseFromOpenAPi(url);

--- a/src/main/java/com/example/dust/metadata/ApiKey.java
+++ b/src/main/java/com/example/dust/metadata/ApiKey.java
@@ -5,4 +5,5 @@ public class ApiKey {
       "mcPOMk6d6ZIiWSfWF0W2X%2B49iH6SeYJyMG61uC1PfEVTWQC7rAepSWCYXt%2F3Rlb5MM2YGP92o28i5qupEEC6WA%3D%3D";
   public static final String STATION_SEARCH_KEY =
       "LFpE9Q72hSFnljuSktMvFC2UrVtz2OSKdZf8PePqPcXB4Ali63V5Q0la6WdtrugkIwsWXeKHctFYjTJr8X%2FVGg%3D%3D";
+  public static final String TRANSFER_COORDINATE_KEY = "2d7cc75a64bcf807f139d9595cb2f46a";
 }

--- a/src/main/java/com/example/dust/metadata/ApiParams.java
+++ b/src/main/java/com/example/dust/metadata/ApiParams.java
@@ -4,14 +4,27 @@ import java.time.LocalDate;
 
 public class ApiParams {
   public static final String FORECAST_SERVICE_KEY = "ServiceKey=" + ApiKey.FORECAST_KEY;
-  public static final String RETURN_TYPE = "_returnType=json";
+  public static final String STATION_SERVICE_KEY = "ServiceKey=" + ApiKey.STATION_SEARCH_KEY;
+
+  public static final String RETURN_TYPE_JSON = "_returnType=json";
 
   //대기예보
   public static final String SEARCH_DATE = "searchDate=" + LocalDate.now().toString();
   public static final String INFORM_CODE = "InformCode=PM10";
 
+  //좌표변환
+  public static final String X = "x=";
+  public static final String Y = "y=";
+  public static final String INPUT_COORD = "input_coord=WGS84";
+  public static final String OUTPUT_COORD = "output_coord=TM";
+
+  //측정소
+  public static final String TM_X = "tmX=";
+  public static final String TM_Y = "tmY=";
+  public static final String VER = "ver=1.0";
+
   //미세먼지
-  public static final String STATION_NAME = "stationName=종로구";
+  public static final String STATION_NAME = "stationName=";
   public static final String DATA_TERM = "dataTerm=DAILY";
   public static final String VERSION = "ver=1.3";
 }

--- a/src/main/java/com/example/dust/metadata/ApiUrl.java
+++ b/src/main/java/com/example/dust/metadata/ApiUrl.java
@@ -7,4 +7,5 @@ public class ApiUrl {
       "http://openapi.airkorea.or.kr/openapi/services/rest/MsrstnInfoInqireSvc/getNearbyMsrstnList";
   public static final String FORECAST =
       "http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth";
+  public static final String TRANSFER_COORDINATE = "https://dapi.kakao.com/v2/local/geo/transcoord.json";
 }

--- a/src/main/java/com/example/dust/util/ConnectionUtil.java
+++ b/src/main/java/com/example/dust/util/ConnectionUtil.java
@@ -1,5 +1,7 @@
 package com.example.dust.util;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -7,11 +9,33 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
+@Slf4j
 public class ConnectionUtil {
 
   public static String getResponseFromOpenAPi(URL url) throws IOException {
     HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
     urlConnection.setRequestMethod("GET");
+
+    BufferedReader bufferedReader =
+        new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8));
+
+    String line;
+    StringBuilder result = new StringBuilder();
+
+    while ((line = bufferedReader.readLine()) != null) {
+      result.append(line);
+    }
+
+    bufferedReader.close();
+    urlConnection.disconnect();
+
+    return result.toString();
+  }
+
+  public static String getResponseFromOpenAPi(URL url, String apikey) throws IOException {
+    HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+    urlConnection.setRequestMethod("GET");
+    urlConnection.setRequestProperty("Authorization", "KakaoAK " + apikey);
 
     BufferedReader bufferedReader =
         new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8));

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 # logging level 설정
 logging.level.root=info
-logging.level.com.codesquad.signup=debug
+logging.level.com.codesquad.dust=debug
 
 # log file path
 logging.file.path=./logs

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,6 +1,6 @@
 # logging level 설정
 logging.level.root=info
-logging.level.com.codesquad.signup=error
+logging.level.com.codesquad.dust=error
 
 # log file path
 logging.file.path=./logs


### PR DESCRIPTION
전체적인 틀은 잡았으나 아직 유동적인 값에 대한 구현이 되지 않았습니다.
좌표 변환부터 재작업할 예정입니다.

- ApiParams.java
  - 좌표변환, 측정소 정보 추가
- ConnectionUtil.java
  - getResponseFromOpenAPi() 오버로딩
    - 기상청 API 는 get 방식에 키를 넣는 것에 비해 kakao api 는 header 에 들어갑니다
      따라서 로직이 달라지기에 오버로딩 하였으며 추후 리팩토링 예정입니다
- ForecastController.java
  - dustStatus() -> getStation() -> transferCoord() 추가